### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/ReactNativeExceptionHandler.podspec
+++ b/ReactNativeExceptionHandler.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/master-atul/react-native-exception-handler.git", :tag => s.version.to_s }
   s.source_files  = "ios/*.{h,m}"
 
-  s.dependency "React"
+  s.dependency "React-Core"
 
 end


### PR DESCRIPTION
Xcode 12 fails to build if a module depends on React instead of React-Core. 
More info: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116