### PR TITLE
fix: still call console.error when hoisting it

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const { ReactNativeExceptionHandler } = NativeModules;
 const noop = () => { };
 
 export const setJSExceptionHandler = (customHandler = noop, allowedInDevMode = false) => {
-  if (typeof allowedInDevMode !== "boolean" || typeof customHandler !== "function"){
+  if (typeof allowedInDevMode !== "boolean" || typeof customHandler !== "function") {
     console.log("setJSExceptionHandler is called with wrong argument types.. first argument should be callback function and second argument is optional should be a boolean");
     console.log("Not setting the JS handler .. please fix setJSExceptionHandler call");
     return;
@@ -13,7 +13,11 @@ export const setJSExceptionHandler = (customHandler = noop, allowedInDevMode = f
   const allowed = allowedInDevMode ? true : !__DEV__;
   if (allowed) {
     global.ErrorUtils.setGlobalHandler(customHandler);
-    console.error = (message, error) => global.ErrorUtils.reportError(error); // sending console.error so that it can be caught
+    const consoleError = console.error;
+    console.error = (...args) => {
+      global.ErrorUtils.reportError(...args);
+      consoleError(...args);
+    };
   } else {
     console.log("Skipping setJSExceptionHandler: Reason: In DEV mode and allowedInDevMode = false");
   }


### PR DESCRIPTION
This is a proposal for the discussion in https://github.com/a7ul/react-native-exception-handler/issues/90
Replacing `console.error` by a function with a different signature can lead to crashes. It also hides any messages that rely on console.error.

I have NOT tested this as I am not an expert in native development.