### PR TITLE
Adding an option to turn off the default error screen on android

### DIFF
--- a/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerModule.java
+++ b/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerModule.java
@@ -34,7 +34,9 @@ public class ReactNativeExceptionHandlerModule extends ReactContextBaseJavaModul
   public void setHandlerforNativeException(
           final boolean executeOriginalUncaughtExceptionHandler,
           final boolean forceToQuit,
-          Callback customHandler) {
+          final boolean disableNativeErrorScreen,
+          Callback customHandler
+          ) {
 
       callbackHolder = customHandler;
       originalHandler = Thread.getDefaultUncaughtExceptionHandler();
@@ -47,18 +49,20 @@ public class ReactNativeExceptionHandlerModule extends ReactContextBaseJavaModul
           String stackTraceString = Log.getStackTraceString(throwable);
           callbackHolder.invoke(stackTraceString);
 
-          if (nativeExceptionHandler != null) {
-              nativeExceptionHandler.handleNativeException(thread, throwable, originalHandler);
-          } else {
-              activity = getCurrentActivity();
+              if (nativeExceptionHandler != null) {
+                  nativeExceptionHandler.handleNativeException(thread, throwable, originalHandler);
+              } else {
+                  if (!disableNativeErrorScreen) {
+                      activity = getCurrentActivity();
 
-              Intent i = new Intent();
-              i.setClass(activity, errorIntentTargetClass);
-              i.putExtra("stack_trace_string",stackTraceString);
-              i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                      Intent i = new Intent();
+                      i.setClass(activity, errorIntentTargetClass);
+                      i.putExtra("stack_trace_string", stackTraceString);
+                      i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
-              activity.startActivity(i);
-              activity.finish();
+                      activity.startActivity(i);
+                      activity.finish();
+                  }
 
               if (executeOriginalUncaughtExceptionHandler && originalHandler != null) {
                   originalHandler.uncaughtException(thread, throwable);

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,4 +9,5 @@ declare const setNativeExceptionHandler: (
 	handler: NativeExceptionHandler,
 	forceAppQuit?: boolean, // Android only
 	executeDefaultHandler?: boolean,
+	disableNativeErrorScreen?: boolean // Android only
 ) => void;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ export const setJSExceptionHandler = (customHandler = noop, allowedInDevMode = f
 
 export const getJSExceptionHandler = () => global.ErrorUtils.getGlobalHandler();
 
-export const setNativeExceptionHandler = (customErrorHandler = noop, forceApplicationToQuit = true, executeDefaultHandler = false) => {
+export const setNativeExceptionHandler = (customErrorHandler = noop, forceApplicationToQuit = true, executeDefaultHandler = false, disableNativeErrorScreen = false) => {
   if (typeof customErrorHandler !== "function" || typeof forceApplicationToQuit !== "boolean") {
     console.log("setNativeExceptionHandler is called with wrong argument types.. first argument should be callback function and second argument is optional should be a boolean");
     console.log("Not setting the native handler .. please fix setNativeExceptionHandler call");
@@ -34,7 +34,12 @@ export const setNativeExceptionHandler = (customErrorHandler = noop, forceApplic
   if (Platform.OS === "ios") {
     ReactNativeExceptionHandler.setHandlerforNativeException(executeDefaultHandler, customErrorHandler);
   } else {
-    ReactNativeExceptionHandler.setHandlerforNativeException(executeDefaultHandler, forceApplicationToQuit, customErrorHandler);
+    ReactNativeExceptionHandler.setHandlerforNativeException(
+      executeDefaultHandler,
+      forceApplicationToQuit,
+      disableNativeErrorScreen,
+      customErrorHandler
+    );
   }
 };
 


### PR DESCRIPTION
This PR introduces a feature that allows users to toggle the default error screen of the react-native-exception-handler library using a parameter from the JavaScript side. This addition provides more flexibility in handling errors according to specific application needs.