### PR TITLE
fix: migrate android artifact repository from jcenter to mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
`jcenter()` repository is deprecated and `mavenCentral()` is the new suggested repository to download dependency artifacts for android projects